### PR TITLE
Add better error message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,12 @@ fn main() {
     let port = env::args().nth(1).unwrap_or("80".to_string());
     let addr = format!("localhost:{}", port);
 
-    println!("Listening on port {}", port);
-    Iron::new(Static::new(".")).http(&*addr).unwrap();
+    match Iron::new(Static::new(".")).http(&*addr) {
+        Ok(_) => {
+            println!("Listening on port {}", port);
+        },
+        Err(_) => {
+            println!("Could not start server on port {}. Do you have permission or is it already in use?", port);
+        },
+    }
 }


### PR DESCRIPTION
When trying to run serve without permission or when another process is
already bound to that port you get a generic Rust error message. This
pattern matches instead of unwrapping Iron and prints the proper output.
