### PR TITLE
Change default port to 8080

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,8 @@ use staticfile::Static;
 use std::env;
 
 fn main() {
-    let port = env::args().nth(1).unwrap_or("80".to_string());
+    let default_port = "8080".to_string();
+    let port = env::args().nth(1).unwrap_or(default_port);
     let addr = format!("localhost:{}", port);
 
     println!("Listening on port {}", port);


### PR DESCRIPTION
Port 80 as a default requires you to run `sudo`. This changes the
default port to 8080 which doesn't require sudo privileges to run.
