### PR TITLE
add docopt for argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,7 @@
 name = "serve"
 version = "0.1.0"
 dependencies = [
+ "docopt 0.6.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "staticfile 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -13,6 +14,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -37,6 +46,16 @@ dependencies = [
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "docopt"
+version = "0.6.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -154,6 +173,14 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "memchr"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mime"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +265,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +308,11 @@ dependencies = [
  "mount 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tempdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.0"
 dependencies = [
  "docopt 0.6.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "staticfile 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Adolfo Ochagavía <aochagavia92@gmail.com>"]
 iron = "0.2.*"
 staticfile = "*"
 docopt = "0.6"
+rustc-serialize = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Adolfo Ochagavía <aochagavia92@gmail.com>"]
 [dependencies]
 iron = "0.2.*"
 staticfile = "*"
+docopt = "0.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,35 @@
 extern crate iron;
 extern crate staticfile;
+extern crate rustc_serialize;
 extern crate docopt;
 
 use iron::Iron;
 use staticfile::Static;
 use docopt::Docopt;
 
-const DEFAULT_PORT: &'static str = "8080";
+const DEFAULT_PORT: u16 = 8080;
 const USAGE: &'static str = "
 Serve files in the current directory via HTTP.
 
-Usage: serve [<port>]
-       serve (-h | --help)
+Usage:
+    serve [<port>]
+    serve (-h | --help)
 
 Options:
-    -h, --help  Show this screen";
+    -h, --help  Show this screen
+";
+
+#[derive(RustcDecodable)]
+struct Args {
+    arg_port: Option<u16>,
+}
 
 fn main() {
-    let args = Docopt::new(USAGE)
-                      .and_then(|dopt| dopt.parse())
-                      .unwrap_or_else(|e| e.exit());
+    let args: Args = Docopt::new(USAGE)
+                            .and_then(|dopt| dopt.decode())
+                            .unwrap_or_else(|e| e.exit());
 
-    let port = if args.get_str("<port>") != "" {
-        args.get_str("<port>").to_string()
-    } else {
-        DEFAULT_PORT.to_string()
-    };
+    let port = args.arg_port.unwrap_or(DEFAULT_PORT);
 
     let addr = format!("localhost:{}", port);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,32 @@
 extern crate iron;
 extern crate staticfile;
+extern crate docopt;
 
 use iron::Iron;
 use staticfile::Static;
-use std::env;
+use docopt::Docopt;
 
 const DEFAULT_PORT: &'static str = "8080";
+const USAGE: &'static str = "
+Serve files in the current directory via HTTP.
+
+Usage: serve [<port>]
+       serve (-h | --help)
+
+Options:
+    -h, --help  Show this screen";
 
 fn main() {
-    let port = env::args().nth(1).unwrap_or(DEFAULT_PORT.into());
+    let args = Docopt::new(USAGE)
+                      .and_then(|dopt| dopt.parse())
+                      .unwrap_or_else(|e| e.exit());
+
+    let port = if args.get_str("<port>") != "" {
+        args.get_str("<port>").to_string()
+    } else {
+        DEFAULT_PORT.to_string()
+    };
+
     let addr = format!("localhost:{}", port);
 
     match Iron::new(Static::new(".")).http(&*addr) {


### PR DESCRIPTION
Parsing arguments directly can become unwieldy when large numbers are involved and type conversions are required. Using docopt makes it easier to add arguments in the future and perform automatic type conversion.
